### PR TITLE
Enabled R8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,7 @@ android {
 
     buildTypes {
         release {
-            // Enables code shrinking, obfuscation, and optimization for only
-            // your project's release build type.
+            // Enables code shrinking, obfuscation, and optimization
             minifyEnabled true
 
             // Enables resource shrinking, which is performed by the

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,13 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            // Enables code shrinking, obfuscation, and optimization for only
+            // your project's release build type.
+            minifyEnabled true
+
+            // Enables resource shrinking, which is performed by the
+            // Android Gradle plugin.
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Not to obfuscate any classes inside models package
+-keep class com.raghav.mynotes.models.*
+# Note - not needed currently as the Keep annotation has already been added to the single class inside models package

--- a/app/src/main/java/com/raghav/mynotes/models/TaskEntity.kt
+++ b/app/src/main/java/com/raghav/mynotes/models/TaskEntity.kt
@@ -1,11 +1,13 @@
 package com.raghav.mynotes.models
 
+import androidx.annotation.Keep
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.io.Serializable
 
 @Entity(tableName = "tasks")
+@Keep
 data class TaskEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Int? = 0,


### PR DESCRIPTION
App Sizes After Clean Build
- before Enabling R8 - 4.3 MB
- after Enabling R8 - 1.9 MB

A deduction of 55.8%