### PR TITLE
Fetch tasks in background thread to avoid ANT

### DIFF
--- a/app/src/main/java/com/raghav/mynotes/prefstore/TaskDatastoreImpl.kt
+++ b/app/src/main/java/com/raghav/mynotes/prefstore/TaskDatastoreImpl.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.raghav.mynotes.utils.Constants.DATASTORE_NAME
+import com.raghav.mynotes.utils.Constants.PREFERENCE_KEY_IS_SORTED
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import java.io.IOException
@@ -36,6 +37,6 @@ class TaskDatastoreImpl @Inject constructor(context: Context) : TaskDatastore {
 
     companion object {
 
-        val IS_SORTED_KEY = booleanPreferencesKey("is_sorted")
+        val IS_SORTED_KEY = booleanPreferencesKey(PREFERENCE_KEY_IS_SORTED)
     }
 }

--- a/app/src/main/java/com/raghav/mynotes/repository/TasksRepository.kt
+++ b/app/src/main/java/com/raghav/mynotes/repository/TasksRepository.kt
@@ -7,7 +7,7 @@ interface TasksRepository {
 
     suspend fun saveTask(task: TaskEntity)
 
-    fun getAllTasks(): Flow<List<TaskEntity>>
+    suspend fun getAllTasks(): Flow<List<TaskEntity>>
 
     suspend fun deleteTask(task: TaskEntity)
 

--- a/app/src/main/java/com/raghav/mynotes/repository/TasksRepositoryImpl.kt
+++ b/app/src/main/java/com/raghav/mynotes/repository/TasksRepositoryImpl.kt
@@ -13,7 +13,7 @@ class TasksRepositoryImpl @Inject constructor(
 ) : TasksRepository {
 
     override suspend fun saveTask(task: TaskEntity) = dao.saveTask(task)
-    override fun getAllTasks() = dao.getTasks()
+    override suspend fun getAllTasks() = dao.getTasks()
     override suspend fun deleteTask(task: TaskEntity) = dao.deleteTask(task)
     override suspend fun saveSortCheckBoxState(checkBoxState: Boolean) = datastore.setValue(
         TaskDatastoreImpl.IS_SORTED_KEY,

--- a/app/src/main/java/com/raghav/mynotes/ui/AllTasksVM.kt
+++ b/app/src/main/java/com/raghav/mynotes/ui/AllTasksVM.kt
@@ -26,7 +26,7 @@ class AllTasksVM @Inject constructor(
     val checkBoxState: LiveData<Boolean> = _checkBoxState
 
     fun getTasks(sort: Boolean = false) {
-        viewModelScope.launch(dispatchers.main) {
+        viewModelScope.launch(dispatchers.io) {
             _tasks.postValue(Resource.Loading())
             repository.getAllTasks().collect {
                 if (sort)
@@ -38,7 +38,7 @@ class AllTasksVM @Inject constructor(
     }
 
     fun deleteTask(task: TaskEntity) {
-        viewModelScope.launch(dispatchers.main) {
+        viewModelScope.launch(dispatchers.io) {
             repository.deleteTask(task)
         }
     }

--- a/app/src/main/java/com/raghav/mynotes/utils/Constants.kt
+++ b/app/src/main/java/com/raghav/mynotes/utils/Constants.kt
@@ -8,4 +8,5 @@ object Constants {
     const val DATE_FORMAT = "E, d MMM yyyy"
     const val DATASTORE_NAME = "task_data_store"
     const val KEY_SAVED_STATE_DEADLINE = "deadline"
+    const val PREFERENCE_KEY_IS_SORTED = "is_sorted"
 }

--- a/app/src/test/java/com/raghav/mynotes/utils/FakeDatastore.kt
+++ b/app/src/test/java/com/raghav/mynotes/utils/FakeDatastore.kt
@@ -3,6 +3,7 @@ package com.raghav.mynotes.utils
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import com.raghav.mynotes.prefstore.TaskDatastore
+import com.raghav.mynotes.utils.Constants.PREFERENCE_KEY_IS_SORTED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -11,8 +12,7 @@ class FakeDatastore : TaskDatastore {
     private var hashMap: HashMap<Any, Any> = HashMap()
 
     companion object {
-
-        private val DUMMY_IS_SORTED_KEY = booleanPreferencesKey("is_sorted")
+        private val DUMMY_IS_SORTED_KEY = booleanPreferencesKey(PREFERENCE_KEY_IS_SORTED)
     }
 
     override val isTasksSorted: Flow<Boolean>


### PR DESCRIPTION
- In case of a large number of tasks, it is better to fetch data on IO thread rather than the main thread because the app will give ANR Error.
- Hardcoded string converted to a constant in the constant file